### PR TITLE
Initialize CF SDK directly

### DIFF
--- a/src/routes/rooms/[slug]/+page.svelte
+++ b/src/routes/rooms/[slug]/+page.svelte
@@ -20,3 +20,11 @@
   <p>Room</p>
   <p>{JSON.stringify(data.room)}</p>  
 </div>
+
+<!-- this should only be rendered in the html sent to the browser -->
+<script type="text/javascript">
+  console.log("you made it to the browser");
+  const _token = "{data.session?.accessToken}";
+  const _host = "relay.swire.io";
+</script>
+<script type="text/javascript" src="https://unpkg.com/@signalwire/js"></script>


### PR DESCRIPTION
goal is to render before close of body, like:

```
  <script type="text/javascript">
    const _token = "<%= token %>";
    const _host = "<%= host %>";
  </script>
  <script type="text/javascript" src="https://unpkg.com/@signalwire/js"></script>
</body>

</html>
```

```
[plugin:vite-plugin-svelte] /Users/ryan/signalwire/dev/call-fabric-sveltekit-example/src/routes/rooms/[slug]/+page.svelte:25:0 A component can only have one instance-level <script> element
/Users/ryan/signalwire/dev/call-fabric-sveltekit-example/src/routes/rooms/[slug]/+page.svelte:25:0
23 |  
 24 |  <!-- this should only be rendered in the html sent to the browser -->
 25 |  <script type="text/javascript">
       ^
 26 |    console.log("you made it to the browser");
 27 |    const _token = "{data.session?.accessToken}";
Click outside, press Esc key, or fix the code to dismiss.
You can also disable this overlay by setting server.hmr.overlay to false in vite.config.ts.
```

![Screenshot 2024-01-12 at 8 27 30 PM](https://github.com/ryanwi/call-fabric-sveltekit-example/assets/49515/8efb6f0e-3d00-482a-b79d-5b82f119371e)
